### PR TITLE
EditCommentのTS化

### DIFF
--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -4,6 +4,7 @@ import ShowCase from './views/ShowCase.vue';
 import TopPage from './views/TopPage.vue';
 import DetailPage from './views/DetailPage.vue';
 import NewOrEditPage from './views/NewOrEditPage.vue';
+import EditComment from './views/EditComment.vue';
 
 Vue.use(Router);
 
@@ -33,6 +34,11 @@ export default new Router({
       path: '/neworeditpage',
       name: 'neworeditpage',
       component: NewOrEditPage
+    },
+    {
+      path: '/editcomment',
+      name: 'editcomment',
+      component: EditComment
     }
   ]
 });

--- a/frontend/src/views/EditComment.vue
+++ b/frontend/src/views/EditComment.vue
@@ -1,74 +1,65 @@
 <template>
   <v-container id="grid" fluid grid-list-sm tag="section">
-    <v-layout class="display-1">
-      コメントを追加・編集する
-    </v-layout>
-    <v-flex xs10 md5>
-      <v-form ref="form">
+    <v-form ref="form" lazy-validation>
+      <v-layout class="display-1">
+        コメントを追加・編集する
+      </v-layout>
+      <v-flex xs10 md5>
         <v-text-field
           v-model="name"
-          :error-messages="nameErrors"
           label="タイトル"
-          @input="$v.name.$touch()"
-          @blur="$v.name.$touch()"
+          :rules="rules"
+          required
         ></v-text-field>
-      </v-form>
-    </v-flex>
-    <v-flex xs12 md8>
-      <v-textarea Filled auto-grow v-model="text" label="コメント">
-      </v-textarea>
-    </v-flex>
-    <v-layout row-wrap>
-      <v-flex md9>
-        <v-btn-toggle v-model="comment_evaluate" mandatory dark>
-          <v-btn flat><i class="fas fa-thumbs-up"></i>Good!!</v-btn>
-          <v-btn flat><i class="fas fa-thumbs-down"></i>Bad</v-btn>
-        </v-btn-toggle>
       </v-flex>
-      <v-flex md3>
-        <v-btn color="info" @click="submit">レビューを投稿する</v-btn>
+      <v-flex xs12 md8>
+        <v-textarea Filled auto-grow v-model="text" label="コメント">
+        </v-textarea>
       </v-flex>
-    </v-layout>
+      <v-layout row-wrap>
+        <v-flex md9>
+          <v-btn-toggle v-model="commentEvaluate" mandatory dark>
+            <v-btn flat><i class="fas fa-thumbs-up"></i>Good!!</v-btn>
+            <v-btn flat><i class="fas fa-thumbs-down"></i>Bad</v-btn>
+          </v-btn-toggle>
+        </v-flex>
+        <v-flex md3>
+          <v-btn color="info" :disabled="!valid" @click="submit"
+            >レビューを投稿する</v-btn
+          >
+        </v-flex>
+      </v-layout>
+    </v-form>
   </v-container>
 </template>
 
-<script>
-import { required } from 'vuelidate/lib/validators';
-import { validationMixin } from 'vuelidate';
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
 
-export default {
-  mixins: [validationMixin],
-  name: 'EditComment',
-  validations: {
-    name: {
-      required
-    }
-  },
-  data: function() {
-    return {
-      name: '',
-      text: '',
-      comment_evaluate: ''
-    };
-  },
-  methods: {
-    submit() {
-      if (!this.$v.$invalid) {
-        alert('submit is pushed!');
-      } else {
-        this.$v.$touch();
-      }
-    }
-  },
-  computed: {
-    nameErrors: function() {
-      const errors = [];
-      if (!this.$v.name.$dirty) return errors;
-      !this.$v.name.required && errors.push('タイトルの入力は必須です');
-      return errors;
-    }
+@Component
+export default class EditComment extends Vue {
+  public static ruleDoNotEmpty(s: string): boolean {
+    return !!s;
   }
-};
+
+  public get rules(): Array<(v: string) => any> {
+    // いつかルール追加するかも・・・？
+    const rules: Array<(v: string) => any> = [];
+    const doNotEmptyRUle = (v: string) =>
+      EditComment.ruleDoNotEmpty(v) || 'Do Not Empty';
+    rules.push(doNotEmptyRUle);
+    return rules;
+  }
+  public name: string = '';
+  public text: string = '';
+  public commentEvaluate: string = '';
+  static submit() {
+    alert('submitted!');
+  }
+  public get valid(): boolean {
+    return !!(this.name)
+  }
+}
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
closed #67 
- TSに変更
- validationの変更
  - Vuetify固有のValidatorに一旦変更(vuelidateムズイ・・・$アクセスが入るとTypeScriptだと型の可能性多すぎて大変なことになりやすそうなので・・・)
- routingに含まれていなかったため追加

空文字列からfalse取って来たい時`!!空文字列`で取ってこれるのめっちゃ便利
